### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ desktopfolder (1.1.2-2) UNRELEASED; urgency=medium
 
   * Set fields Upstream-Name, Upstream-Contact in debian/copyright.
   * Use canonical URL in Vcs-Git.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata
+    (already present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 02:06:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 desktopfolder (1.1.2-2) UNRELEASED; urgency=medium
 
   * Set fields Upstream-Name, Upstream-Contact in debian/copyright.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 02:06:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ desktopfolder (1.1.2-2) UNRELEASED; urgency=medium
   * Use canonical URL in Vcs-Git.
   * Remove obsolete fields Contact, Name from debian/upstream/metadata
     (already present in machine-readable debian/copyright).
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 02:06:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+desktopfolder (1.1.2-2) UNRELEASED; urgency=medium
+
+  * Set fields Upstream-Name, Upstream-Contact in debian/copyright.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 02:06:54 +0000
+
 desktopfolder (1.1.2-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 12),
                intltool
 Standards-Version: 4.4.1
 Vcs-Browser: https://github.com/UbuntuBudgie/desktopfolder/tree/debian
-Vcs-Git: https://github.com/UbuntuBudgie/desktopfolder -b debian
+Vcs-Git: https://github.com/UbuntuBudgie/desktopfolder.git -b debian
 Homepage: https://github.com/spheras/desktopfolder
 
 Package: desktopfolder

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 12),
                libglib2.0-dev,
                libgtksourceview-3.0-dev,
                intltool
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Browser: https://github.com/UbuntuBudgie/desktopfolder/tree/debian
 Vcs-Git: https://github.com/UbuntuBudgie/desktopfolder.git -b debian
 Homepage: https://github.com/spheras/desktopfolder

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: desktopfolder
+Upstream-Contact: José Amuedo <joseamuedo@gmail.com>
 
 Files: *
 Copyright: 2017-2019, José Amuedo (https:github.com/spheras)

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,8 +1,6 @@
 ---
-Name: desktopfolder
 Bug-Database: https://github.com/spheras/desktopfolder
 Cite-As: "Bring your Desktop Back to Life."
-Contact: José Amuedo <joseamuedo@gmail.com>
 Repository: https://github.com/spheras/desktopfolder.git
 Repository-Browse: https://github.com/spheras/desktopfolder
 Screenshots: https://github.com/spheras/desktopfolder


### PR DESCRIPTION
Fix some issues reported by lintian
* Set fields Upstream-Name, Upstream-Contact in debian/copyright.
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/desktopfolder/67eb4ab2-6eb9-4687-8511-c1d838bb78f6.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ff/f5bb4531ce7e7d4d9074d62dca59b9df92d234.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/1f/bf0ea3e5ef8a76c83f0bc91d8913349eea40e2.debug

No differences were encountered between the control files of package \*\*desktopfolder\*\*
### Control files of package desktopfolder-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-1fbf0ea3e5ef8a76c83f0bc91d8913349eea40e2-] {+fff5bb4531ce7e7d4d9074d62dca59b9df92d234+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/67eb4ab2-6eb9-4687-8511-c1d838bb78f6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/67eb4ab2-6eb9-4687-8511-c1d838bb78f6/diffoscope)).
